### PR TITLE
feat: docker compose stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ cp .env.example .env
 docker compose up -d
 ```
 
-Para guías completas, arquitectura y API, visita la [documentación](./docs).
+Para guías completas, variables de entorno y arquitectura visita la [documentación](./docs).
 
 ## Estructura del repositorio
 

--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -1,8 +1,10 @@
 # Build stage
 FROM node:20-alpine AS build
 WORKDIR /app
+COPY package.json ./
+RUN npm i -g pnpm && pnpm install
 COPY . .
-RUN npm i -g pnpm && pnpm install --prod && pnpm build
+RUN pnpm build
 
 # Runtime stage
 FROM nginx:alpine

--- a/apps/kiosk-touch/Dockerfile
+++ b/apps/kiosk-touch/Dockerfile
@@ -1,8 +1,10 @@
 # Build stage
 FROM node:20-alpine AS build
 WORKDIR /app
+COPY package.json ./
+RUN npm i -g pnpm && pnpm install
 COPY . .
-RUN npm i -g pnpm && pnpm install --prod && pnpm build
+RUN pnpm build
 
 # Runtime stage
 FROM nginx:alpine

--- a/apps/monitor/Dockerfile
+++ b/apps/monitor/Dockerfile
@@ -1,8 +1,10 @@
 # Build stage
 FROM node:20-alpine AS build
 WORKDIR /app
+COPY package.json ./
+RUN npm i -g pnpm && pnpm install
 COPY . .
-RUN npm i -g pnpm && pnpm install --prod && pnpm build
+RUN pnpm build
 
 # Runtime stage
 FROM nginx:alpine

--- a/apps/operator/Dockerfile
+++ b/apps/operator/Dockerfile
@@ -1,8 +1,10 @@
 # Build stage
 FROM node:20-alpine AS build
 WORKDIR /app
+COPY package.json ./
+RUN npm i -g pnpm && pnpm install
 COPY . .
-RUN npm i -g pnpm && pnpm install --prod && pnpm build
+RUN pnpm build
 
 # Runtime stage
 FROM nginx:alpine

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -23,11 +23,22 @@ Este documento describe cómo preparar un entorno local de **QuipuQ** utilizando
    ```
    Ajusta los valores de `.env` según tu entorno si es necesario.
 
+   ### Variables de entorno
+   El archivo `.env.example` incluye valores para:
+   - `DATABASE_URL`
+   - `REDIS_URL`
+   - `OIDC_ISSUER_URL`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, `OIDC_REDIRECT_URI`
+   - `RENIEC_BASE_URL`, `RENIEC_API_KEY`, `RENIEC_TIMEOUT_MS`
+   - `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `WEBHOOK_URL`
+   - `TENANT_DEFAULT`, `SEED_ON_START`
+   - `API_PORT`, `NOTIFICATION_PORT`, `RENIEC_ADAPTER_PORT`
+   - `PUBLIC_BASE_URL`
+
 3. **Levantar los servicios**
    ```bash
    docker compose up -d
    ```
-   Esto iniciará PostgreSQL, Redis y los servicios básicos definidos en `docker-compose.yml`.
+   Esto iniciará PostgreSQL, Redis y los servicios definidos en `docker-compose.yml`.
 
 4. **Verificar el estado de los contenedores**
    ```bash
@@ -43,4 +54,3 @@ Este documento describe cómo preparar un entorno local de **QuipuQ** utilizando
 
 - Los volúmenes de Docker almacenan los datos de la base de datos y se conservan entre reinicios.
 - Para reconstruir las imágenes después de cambios, usa `docker compose build`.
-

--- a/infra/docker/.env.example
+++ b/infra/docker/.env.example
@@ -1,26 +1,32 @@
-# DB/Cache
-DATABASE_URL=postgresql://postgres:postgres@postgres:5432/quipuq
+# DB / Cache
+DATABASE_URL=postgresql://postgres:postgres@postgres:5432/quipuq?schema=public
 REDIS_URL=redis://redis:6379
 
-# Auth (Keycloak/OIDC)
-OIDC_ISSUER_URL=
-OIDC_CLIENT_ID=
-OIDC_CLIENT_SECRET=
-OIDC_REDIRECT_URI=
+# Auth (Keycloak/OIDC) - dev values
+OIDC_ISSUER_URL=http://keycloak:8080/realms/upeu
+OIDC_CLIENT_ID=quipuq-web
+OIDC_CLIENT_SECRET=replace_me
+OIDC_REDIRECT_URI=http://localhost/admin/callback
 
 # RENIEC Adapter
 RENIEC_BASE_URL=http://reniec-adapter:3002
-RENIEC_API_KEY=
+RENIEC_API_KEY=replace_me
 RENIEC_TIMEOUT_MS=800
 
 # Notification
-SMTP_HOST=
-SMTP_PORT=
+SMTP_HOST=mailhog
+SMTP_PORT=1025
 SMTP_USER=
 SMTP_PASS=
-WEBHOOK_URL=
+WEBHOOK_URL=http://n8n:5678/webhook/quipuq
 
 # App
 NODE_ENV=production
 TENANT_DEFAULT=upeu
 SEED_ON_START=true
+API_PORT=3000
+NOTIFICATION_PORT=3001
+RENIEC_ADAPTER_PORT=3002
+
+# Nginx
+PUBLIC_BASE_URL=http://localhost

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -4,55 +4,112 @@ services:
     image: postgres:16
     restart: always
     environment:
-      POSTGRES_USER: quipuq
-      POSTGRES_PASSWORD: quipuq
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
       POSTGRES_DB: quipuq
+    healthcheck:
+      test: ['CMD', 'pg_isready', '-U', 'postgres']
+      interval: 5s
+      retries: 5
     ports:
       - '5432:5432'
+
   redis:
     image: redis:7
     restart: always
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 5s
+      retries: 5
     ports:
       - '6379:6379'
+
   api:
     build: ../../services/api
-    depends_on: [postgres, redis]
+    env_file: .env
     environment:
-      - PORT=3000
+      - PORT=${API_PORT}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://localhost:3000']
+      interval: 10s
+      retries: 5
     ports:
-      - '3000:3000'
+      - '${API_PORT:-3000}:3000'
+
   notification:
     build: ../../services/notification
+    env_file: .env
     environment:
-      - PORT=4000
+      - PORT=${NOTIFICATION_PORT}
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://localhost:3001']
+      interval: 10s
+      retries: 5
     ports:
-      - '4000:4000'
-  reniec:
+      - '${NOTIFICATION_PORT:-3001}:3001'
+
+  reniec-adapter:
     build: ../../services/reniec-adapter
+    env_file: .env
     environment:
-      - PORT=4100
+      - PORT=${RENIEC_ADAPTER_PORT}
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://localhost:3002']
+      interval: 10s
+      retries: 5
     ports:
-      - '4100:4100'
+      - '${RENIEC_ADAPTER_PORT:-3002}:3002'
+
   admin:
     build: ../../apps/admin
     ports:
-      - '5173:5173'
+      - '5173:80'
+
   operator:
     build: ../../apps/operator
     ports:
-      - '5174:5173'
+      - '5174:80'
+
   kiosk:
     build: ../../apps/kiosk-touch
     ports:
-      - '5175:5173'
+      - '5175:80'
+
   monitor:
     build: ../../apps/monitor
     ports:
-      - '5176:5173'
+      - '5176:80'
+
   nginx:
     image: nginx:1.25
     volumes:
       - ../nginx/default.conf:/etc/nginx/conf.d/default.conf
+    depends_on:
+      api:
+        condition: service_healthy
+      notification:
+        condition: service_healthy
+      reniec-adapter:
+        condition: service_healthy
+      admin:
+        condition: service_started
+      operator:
+        condition: service_started
+      kiosk:
+        condition: service_started
+      monitor:
+        condition: service_started
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://localhost']
+      interval: 10s
+      retries: 5
     ports:
       - '8080:80'
-    depends_on: [api, notification, reniec]

--- a/infra/nginx/default.conf
+++ b/infra/nginx/default.conf
@@ -1,20 +1,42 @@
 server {
   listen 80;
 
+  gzip on;
+  gzip_types text/plain application/javascript application/json text/css image/svg+xml;
+
   location /api/ {
     proxy_pass http://api:3000/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection 'upgrade';
+    proxy_set_header Host $host;
   }
 
   location /notify/ {
-    proxy_pass http://notification:4000/;
+    proxy_pass http://notification:3001/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection 'upgrade';
+    proxy_set_header Host $host;
   }
 
   location /reniec/ {
-    proxy_pass http://reniec:4100/;
+    proxy_pass http://reniec-adapter:3002/;
   }
 
-  location / {
-    root /usr/share/nginx/html;
-    try_files $uri $uri/ /index.html;
+  location /admin/ {
+    proxy_pass http://admin/;
+  }
+
+  location /operator/ {
+    proxy_pass http://operator/;
+  }
+
+  location /kiosk/ {
+    proxy_pass http://kiosk/;
+  }
+
+  location /monitor/ {
+    proxy_pass http://monitor/;
   }
 }

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -1,5 +1,21 @@
+# Install dependencies
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json ./
+RUN npm i -g pnpm && pnpm install
+
+# Build
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN pnpm build
+
+# Runtime
 FROM node:20-alpine
 WORKDIR /app
-COPY . .
-RUN npm i -g pnpm && pnpm install --prod && pnpm build
-CMD ["node","dist/main.js"]
+ENV NODE_ENV=production
+COPY --from=build /app/dist ./dist
+COPY package.json ./
+RUN npm i -g pnpm && pnpm install --prod
+CMD ["sh", "-c", "pnpm prisma migrate deploy || true && node dist/main.js"]

--- a/services/api/src/main.ts
+++ b/services/api/src/main.ts
@@ -3,6 +3,12 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  await app.listen(process.env.PORT || 3000);
+  const origins = (process.env.CORS_ORIGIN || '').split(',').filter(Boolean);
+  if (origins.length > 0) {
+    app.enableCors({ origin: origins });
+  } else {
+    app.enableCors();
+  }
+  await app.listen(process.env.API_PORT || process.env.PORT || 3000);
 }
 bootstrap();

--- a/services/notification/Dockerfile
+++ b/services/notification/Dockerfile
@@ -1,5 +1,21 @@
+# Install dependencies
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json ./
+RUN npm i -g pnpm && pnpm install
+
+# Build
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN pnpm build
+
+# Runtime
 FROM node:20-alpine
 WORKDIR /app
-COPY . .
-RUN npm i -g pnpm && pnpm install --prod && pnpm build
-CMD ["node","dist/index.js"]
+ENV NODE_ENV=production
+COPY --from=build /app/dist ./dist
+COPY package.json ./
+RUN npm i -g pnpm && pnpm install --prod
+CMD ["node", "dist/index.js"]

--- a/services/reniec-adapter/Dockerfile
+++ b/services/reniec-adapter/Dockerfile
@@ -1,5 +1,21 @@
+# Install dependencies
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json ./
+RUN npm i -g pnpm && pnpm install
+
+# Build
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN pnpm build
+
+# Runtime
 FROM node:20-alpine
 WORKDIR /app
-COPY . .
-RUN npm i -g pnpm && pnpm install --prod && pnpm build
-CMD ["node","dist/index.js"]
+ENV NODE_ENV=production
+COPY --from=build /app/dist ./dist
+COPY package.json ./
+RUN npm i -g pnpm && pnpm install --prod
+CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## Summary
- add example env file for docker stack
- expand docker-compose with healthchecks and env support
- enable CORS in API and proxy WebSockets through nginx
- document environment variables in installation guide

## Testing
- `pnpm lint` *(fails: ESLint couldn't find a configuration file in apps/operator)*

------
https://chatgpt.com/codex/tasks/task_e_689a78f786208326be01e845598ed67c