### PR TITLE
fix: include base tsconfig in docker builds

### DIFF
--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -25,7 +25,9 @@ services:
       - '6379:6379'
 
   api:
-    build: ../../services/api
+    build:
+      context: ../..
+      dockerfile: services/api/Dockerfile
     env_file: .env
     environment:
       - PORT=${API_PORT}
@@ -42,7 +44,9 @@ services:
       - '${API_PORT:-3000}:3000'
 
   notification:
-    build: ../../services/notification
+    build:
+      context: ../..
+      dockerfile: services/notification/Dockerfile
     env_file: .env
     environment:
       - PORT=${NOTIFICATION_PORT}
@@ -57,7 +61,9 @@ services:
       - '${NOTIFICATION_PORT:-3001}:3001'
 
   reniec-adapter:
-    build: ../../services/reniec-adapter
+    build:
+      context: ../..
+      dockerfile: services/reniec-adapter/Dockerfile
     env_file: .env
     environment:
       - PORT=${RENIEC_ADAPTER_PORT}
@@ -69,22 +75,30 @@ services:
       - '${RENIEC_ADAPTER_PORT:-3002}:3002'
 
   admin:
-    build: ../../apps/admin
+    build:
+      context: ../..
+      dockerfile: apps/admin/Dockerfile
     ports:
       - '5173:80'
 
   operator:
-    build: ../../apps/operator
+    build:
+      context: ../..
+      dockerfile: apps/operator/Dockerfile
     ports:
       - '5174:80'
 
   kiosk:
-    build: ../../apps/kiosk-touch
+    build:
+      context: ../..
+      dockerfile: apps/kiosk-touch/Dockerfile
     ports:
       - '5175:80'
 
   monitor:
-    build: ../../apps/monitor
+    build:
+      context: ../..
+      dockerfile: apps/monitor/Dockerfile
     ports:
       - '5176:80'
 


### PR DESCRIPTION
## Summary
- ensure docker builds use repo root as context so tsconfig.base.json is available

## Testing
- `docker-compose config`

------
https://chatgpt.com/codex/tasks/task_e_689a7d13c09483268e7f5f0b7d2fe3b9