### PR TITLE
chore: standardize docker setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint-test-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: corepack enable && corepack prepare pnpm@10.13.1 --activate
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+      - run: pnpm test
+      - run: pnpm build
+
+  docker-build:
+    runs-on: ubuntu-latest
+    needs: lint-test-build
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker compose -f infra/docker/docker-compose.yml build

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Monorepo del sistema de gestión de colas **QuipuQ**.
 ```bash
 cd infra/docker
 cp .env.example .env
-docker compose up -d
+docker compose up -d --build
+./smoke.sh # optional smoke test
 ```
 
 Para guías completas, variables de entorno y arquitectura visita la [documentación](./docs).

--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -2,8 +2,7 @@ FROM node:20-alpine AS build
 WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@10.13.1 --activate
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-COPY apps/admin/package.json apps/admin/
-RUN pnpm install --filter @quipuq/admin --frozen-lockfile
+RUN pnpm install --frozen-lockfile
 COPY . .
 RUN pnpm build --filter @quipuq/admin
 

--- a/apps/kiosk-touch/Dockerfile
+++ b/apps/kiosk-touch/Dockerfile
@@ -2,8 +2,7 @@ FROM node:20-alpine AS build
 WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@10.13.1 --activate
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-COPY apps/kiosk-touch/package.json apps/kiosk-touch/
-RUN pnpm install --filter @quipuq/kiosk-touch --frozen-lockfile
+RUN pnpm install --frozen-lockfile
 COPY . .
 RUN pnpm build --filter @quipuq/kiosk-touch
 

--- a/apps/monitor/Dockerfile
+++ b/apps/monitor/Dockerfile
@@ -2,8 +2,7 @@ FROM node:20-alpine AS build
 WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@10.13.1 --activate
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-COPY apps/monitor/package.json apps/monitor/
-RUN pnpm install --filter @quipuq/monitor --frozen-lockfile
+RUN pnpm install --frozen-lockfile
 COPY . .
 RUN pnpm build --filter @quipuq/monitor
 

--- a/apps/operator/Dockerfile
+++ b/apps/operator/Dockerfile
@@ -2,8 +2,7 @@ FROM node:20-alpine AS build
 WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@10.13.1 --activate
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-COPY apps/operator/package.json apps/operator/
-RUN pnpm install --filter @quipuq/operator --frozen-lockfile
+RUN pnpm install --frozen-lockfile
 COPY . .
 RUN pnpm build --filter @quipuq/operator
 

--- a/infra/docker/.env.example
+++ b/infra/docker/.env.example
@@ -1,32 +1,22 @@
-# DB / Cache
 DATABASE_URL=postgresql://postgres:postgres@postgres:5432/quipuq?schema=public
 REDIS_URL=redis://redis:6379
-
-# Auth (Keycloak/OIDC) - dev values
 OIDC_ISSUER_URL=http://keycloak:8080/realms/upeu
 OIDC_CLIENT_ID=quipuq-web
 OIDC_CLIENT_SECRET=replace_me
 OIDC_REDIRECT_URI=http://localhost/admin/callback
-
-# RENIEC Adapter
 RENIEC_BASE_URL=http://reniec-adapter:3002
 RENIEC_API_KEY=replace_me
 RENIEC_TIMEOUT_MS=800
-
-# Notification
 SMTP_HOST=mailhog
 SMTP_PORT=1025
 SMTP_USER=
 SMTP_PASS=
 WEBHOOK_URL=http://n8n:5678/webhook/quipuq
-
-# App
 NODE_ENV=production
 TENANT_DEFAULT=upeu
 SEED_ON_START=true
 API_PORT=3000
 NOTIFICATION_PORT=3001
 RENIEC_ADAPTER_PORT=3002
-
-# Nginx
 PUBLIC_BASE_URL=http://localhost
+CORS_ORIGIN=http://localhost/admin,http://localhost/operator,http://localhost/kiosk,http://localhost/monitor

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -80,6 +80,10 @@ services:
       dockerfile: apps/admin/Dockerfile
     ports:
       - '5173:80'
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://localhost']
+      interval: 10s
+      retries: 5
 
   operator:
     build:
@@ -87,6 +91,10 @@ services:
       dockerfile: apps/operator/Dockerfile
     ports:
       - '5174:80'
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://localhost']
+      interval: 10s
+      retries: 5
 
   kiosk:
     build:
@@ -94,6 +102,10 @@ services:
       dockerfile: apps/kiosk-touch/Dockerfile
     ports:
       - '5175:80'
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://localhost']
+      interval: 10s
+      retries: 5
 
   monitor:
     build:
@@ -101,6 +113,10 @@ services:
       dockerfile: apps/monitor/Dockerfile
     ports:
       - '5176:80'
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://localhost']
+      interval: 10s
+      retries: 5
 
   nginx:
     image: nginx:1.25
@@ -114,13 +130,13 @@ services:
       reniec-adapter:
         condition: service_healthy
       admin:
-        condition: service_started
+        condition: service_healthy
       operator:
-        condition: service_started
+        condition: service_healthy
       kiosk:
-        condition: service_started
+        condition: service_healthy
       monitor:
-        condition: service_started
+        condition: service_healthy
     healthcheck:
       test: ['CMD', 'wget', '-qO-', 'http://localhost']
       interval: 10s

--- a/infra/docker/smoke.sh
+++ b/infra/docker/smoke.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Wait for containers to report healthy
+required=(api notification reniec-adapter nginx)
+for svc in "${required[@]}"; do
+  printf 'Waiting for %s to be healthy...\n' "$svc"
+  until [ "$(docker compose ps -q "$svc" 2>/dev/null)" ] && \
+        [ "$(docker inspect -f '{{.State.Health.Status}}' $(docker compose ps -q "$svc"))" = "healthy" ]; do
+    sleep 1
+  done
+  printf '%s healthy\n' "$svc"
+done
+
+# Basic health endpoint check
+curl -fsSL http://localhost:8080/api/health
+
+# TODO: add ticket creation and WebSocket verification

--- a/infra/nginx/default.conf
+++ b/infra/nginx/default.conf
@@ -8,7 +8,7 @@ server {
     proxy_pass http://api:3000/;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection 'upgrade';
+    proxy_set_header Connection "upgrade";
     proxy_set_header Host $host;
   }
 
@@ -16,12 +16,16 @@ server {
     proxy_pass http://notification:3001/;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection 'upgrade';
+    proxy_set_header Connection "upgrade";
     proxy_set_header Host $host;
   }
 
   location /reniec/ {
     proxy_pass http://reniec-adapter:3002/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
   }
 
   location /admin/ {

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -14,9 +14,9 @@ FROM node:20-alpine AS runtime
 WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@10.13.1 --activate
 COPY --from=build /app/services/api/dist ./dist
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-COPY services/api/package.json ./
-COPY prisma ./prisma
-RUN pnpm install --prod --filter @quipuq/api --frozen-lockfile
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY services/api/package.json ./package.json
+COPY services/api/prisma ./prisma
+RUN pnpm install --prod --frozen-lockfile --filter @quipuq/api
 ENV NODE_ENV=production
-CMD sh -c "pnpm prisma migrate deploy && node dist/main.js"
+CMD sh -c "pnpm prisma migrate deploy && if [ \"$SEED_ON_START\" = \"true\" ]; then pnpm prisma db seed; fi && node dist/main.js"

--- a/services/notification/Dockerfile
+++ b/services/notification/Dockerfile
@@ -14,8 +14,8 @@ FROM node:20-alpine AS runtime
 WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@10.13.1 --activate
 COPY --from=build /app/services/notification/dist ./dist
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-COPY services/notification/package.json ./
-RUN pnpm install --prod --filter @quipuq/notification --frozen-lockfile
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY services/notification/package.json ./package.json
+RUN pnpm install --prod --frozen-lockfile --filter @quipuq/notification
 ENV NODE_ENV=production
 CMD ["node", "dist/index.js"]

--- a/services/reniec-adapter/Dockerfile
+++ b/services/reniec-adapter/Dockerfile
@@ -14,8 +14,8 @@ FROM node:20-alpine AS runtime
 WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@10.13.1 --activate
 COPY --from=build /app/services/reniec-adapter/dist ./dist
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-COPY services/reniec-adapter/package.json ./
-RUN pnpm install --prod --filter @quipuq/reniec-adapter --frozen-lockfile
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY services/reniec-adapter/package.json ./package.json
+RUN pnpm install --prod --frozen-lockfile --filter @quipuq/reniec-adapter
 ENV NODE_ENV=production
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## Summary
- multi-stage Dockerfiles for services and apps using pnpm
- add Docker compose env example, healthchecks, and smoke script
- add CI workflow and README quickstart

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm lint` *(fails: ESLint couldn't find a configuration file)*
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689a85ce5d008326aa062373aec7a089